### PR TITLE
x,y,z coordinates output problem

### DIFF
--- a/src/vector.py
+++ b/src/vector.py
@@ -393,7 +393,7 @@ class Vector:
             # return "{type: <6}{idx: >5}{atype: <5}{alt1:1}{resname: >3} {chain:1}{resid:>4}{alt2:1}   {x:> 8.3f}{y:> 8.3f}{z:> 8.3f}{user:> 6.2f}{beta:> 6.2f}          {et:2}".format(\
             # type=self.type, idx=self.idx,atype=self.atype,alt1=altconf,alt2=self.altConf2,resname=self.aa,\
             # chain=self.chain,resid=self.resid,x=self.x,y=self.y,z=self.z,user=self.user,beta=self.beta,et=self.elementType)
-            return "{type: <6}{idx: >5}{atype: <5}{alt1:1}{resname: >3} {chain:1}{resid:>4}{alt2:1}   {x:> 8.3f}{y:> 8.3f}{z:> 8.3f}{user: >6.2f}{beta: >6.2f}{et: >12}".format(\
+            return "{type: <6}{idx: >5}{atype: <5}{alt1:1}{resname: >3} {chain:1}{resid:>4}{alt2:1}   {x:>8.3f}{y:>8.3f}{z:>8.3f}{user: >6.2f}{beta: >6.2f}{et: >12}".format(\
             type=self.type, idx=self.idx,atype=self.atype,alt1=altconf,alt2=self.altConf2,resname=self.aa,\
             chain=self.chain,resid=self.resid,x=self.x,y=self.y,z=self.z,user=self.user,beta=self.beta,et=self.elementType)
         else:


### PR DESCRIPTION
In some pdb the are coordinates with 4 integers and 3 float (eg 1q55.pdb)
ATOM    950  N   VAL A 117    2015.8492119.467 309.385  1.00 41.71           N

output method of vector.py write pdb in the following format:
ATOM    950  N   VAL A 117     2015.849 2119.467 309.385  1.00 10.00           N

there is a space between x and y coordinates. Now, if I read the output file using p3d I receive the pattern mismatch error.

I correct the output() method. Check if its correct.
